### PR TITLE
Fix tooltip memory leak: destroy doesn't destroy $tip & $arrow

### DIFF
--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -436,6 +436,11 @@
     clearTimeout(this.timeout)
     this.hide(function () {
       that.$element.off('.' + that.type).removeData('bs.' + that.type)
+      if (that.$tip) {
+        that.$tip.detach()
+      }
+      that.$tip = null
+      that.$arrow = null
     })
   }
 


### PR DESCRIPTION
This is the squashed one of #15637.
